### PR TITLE
Add {tibble} as a dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,12 @@ Imports:
     cli,
     httr,
     jsonlite,
-    magrittr
+    magrittr,
+    pillar,
+    tibble,
+    vctrs
 Suggests: 
     data.tree,
-    pillar,
     rappdirs,
     xml2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     jsonlite,
     magrittr,
     pillar,
-    tibble,
     vctrs
 Suggests: 
     data.tree,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,8 @@
 S3method(as.character,od_json)
 S3method(as.character,sc_json)
 S3method(as.data.frame,sc_data)
+S3method(format,sc_schema_uri)
+S3method(pillar_shaft,sc_schema_uri)
 S3method(print,od_cache_file)
 S3method(print,od_json)
 S3method(print,od_revisions)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(as.character,od_json)
 S3method(as.character,sc_json)
+S3method(as.character,sc_schema_uri)
 S3method(as.data.frame,sc_data)
 S3method(format,sc_schema_uri)
 S3method(pillar_shaft,sc_schema_uri)
@@ -67,3 +68,4 @@ export(sc_tabulate)
 importFrom(magrittr,"%<>%")
 importFrom(magrittr,"%>%")
 importFrom(magrittr,"%T>%")
+importFrom(pillar,pillar_shaft)

--- a/R/schema_uri.R
+++ b/R/schema_uri.R
@@ -1,0 +1,67 @@
+new_schema_uri <- function(label, uri) {
+  vctrs::vec_assert(label, character())
+  vctrs::vec_assert(uri, character())
+  vctrs::new_rcrd(list(label = label, uri = uri), class = "sc_schema_uri")
+}
+
+#' @export
+format.sc_schema_uri <- function(x, ...) {
+  format(vctrs::field(x, "label"), ...)
+}
+
+sc_schema_run <- function(uri) {
+  run <- paste0("STATcubeR::sc_schema(\"", uri, "\")")
+  is_table <- grep("^str:table", uri)
+  run[is_table] <- paste0("STATcubeR::sc_table_saved(\"", uri[is_table], "\")")
+  run
+}
+
+sc_schema_url <- function(uri) {
+  url <- rep(NA_character_, length(uri))
+  is_database <- grep("^str:database", uri)
+  if (length(is_database) > 0)
+    url[is_database] <- uri[is_database] %>%
+    sub("^str:database:", "", .) %>%
+    sc_browse_database(server = "ext") %>%
+    as.character()
+  is_table <- grepl("^str:table", uri) &
+    !grepl("^([0-9a-f-])+$", sub("str:table:", "", uri))
+  if (length(is_table) > 0)
+    url[is_table] <- uri[is_table] %>%
+    sub("^str:table:", "", .) %>%
+    sc_browse_table(server = "ext") %>%
+    as.character()
+  url
+}
+
+#' @importFrom pillar pillar_shaft
+#' @export
+pillar_shaft.sc_schema_uri <- function(x, ...) {
+  label <- vctrs::field(x, "label")
+  formatted <- label
+  short_formatted <- substr(formatted, 1, 40)
+  uri <- vctrs::field(x, "uri")
+  if (cli::ansi_hyperlink_types()$run) {
+    run <- sc_schema_run(uri)
+    template <- cli::format_inline("{.run [%s](%s)}") %>% cli::style_underline()
+    formatted <- sprintf(template, run, formatted)
+    short_formatted <- sprintf(template, run, short_formatted)
+  } else if (cli::ansi_has_hyperlink_support()) {
+    url <- sc_schema_url(uri)
+    formatted[!is.na(url)] <- cli::style_hyperlink(formatted[!is.na(url)],
+       url[!is.na(url)])
+    short_formatted[!is.na(url)] <- cli::style_hyperlink(
+      short_formatted[!is.na(url)], url[!is.na(url)])
+  }
+  pillar::new_pillar_shaft_simple(
+    formatted,
+    width = max(nchar(label)),
+    min_width = 40,
+    type_sum = "chr",
+    short_formatted = short_formatted
+  )
+}
+
+as.character.sc_schema_uri <- function(x, ...) {
+  format(x)
+}

--- a/R/schema_uri.R
+++ b/R/schema_uri.R
@@ -62,6 +62,7 @@ pillar_shaft.sc_schema_uri <- function(x, ...) {
   )
 }
 
+#' @export
 as.character.sc_schema_uri <- function(x, ...) {
   format(x)
 }

--- a/R/table_saved.R
+++ b/R/table_saved.R
@@ -24,6 +24,7 @@ sc_table_saved_list <- function(key = NULL, server = "ext") {
 #' @export
 sc_table_saved <- function(table_uri, language = NULL, key = NULL, server = "ext") {
   language <- sc_language(language)
+  table_uri <- as.character(table_uri)
   if (substr(table_uri, 1, 3) != "str")
     table_uri <- paste0("str:table:", table_uri)
   sc_with_cache(c("sc_table_saved", table_uri, language, key), function() {

--- a/R/table_saved.R
+++ b/R/table_saved.R
@@ -9,10 +9,13 @@ sc_table_saved_list <- function(key = NULL, server = "ext") {
 
   tables <- schema %>% sapply(function(x) x$type == "TABLE")
   saved_tables <- schema[tables]
-  data.frame(
+  vctrs::new_data_frame(list(
     label = sapply(saved_tables, function(x) x$label),
-    id = sapply(saved_tables, function(x) x$id)
-  )
+    id = new_schema_uri(
+      sapply(saved_tables, function(x) x$id),
+      sapply(saved_tables, function(x) x$id)
+    )
+  ), class = c("tbl", "tbl_df"))
 }
 
 #' @param table_uri Identifier of a saved table as returned by


### PR DESCRIPTION
STATcubeR did customize the df printing using "tibble-generics" for a while now. This branch will add a proper dependency to the `{tibble}` package and also includes some custom vector classes using `{vctrs}`.

- [ ] add class for schema
- [ ] add class for schema types
- [ ] use `@export` instead of `registerS3method()`
- [ ] Update S3 methods for "STATcubeR-metadata"