### PR TITLE
Depends: cli only exports cli_fmt() in v3.4.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ License: GPL (>= 2)
 URL: https://statistikat.github.io/STATcubeR,
     https://github.com/statistikat/STATcubeR
 Imports: 
-    cli,
+    cli (>= 3.4.1),
     httr,
     jsonlite,
     magrittr


### PR DESCRIPTION
Otherwise sc_table() fails with "Error: 'cli_fmt' is not an exported object from 'namespace:cli'"

Reference https://github.com/r-lib/cli/commit/c4568e439ee37f0fea39aa96c341ec387a494494