### PR TITLE
sc_table: Allow json request to be passed as string

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -170,6 +170,8 @@ sc_table_class <- R6::R6Class(
 #' Those three functions all return an object of class `"sc_table"`.
 #' @param json_file path to a json file, which was downloaded via the STATcube
 #'   GUI ("Open Data API Abfrage")
+#' @param json A string representing a json file downloaded via STATcube
+#'   (readLines(json_file))
 #' @param add_totals Should totals be added for each classification field in
 #'   the json request?
 #' @return An object of class `sc_table` which contains the return
@@ -206,13 +208,15 @@ sc_table_class <- R6::R6Class(
 #' my_response <- sc_table_saved(table_uri)
 #' as.data.frame(my_response)
 #' @export
-sc_table <- function(json_file, language = NULL, add_totals = TRUE,
+sc_table <- function(json_file = NULL, json = NULL, language = NULL, add_totals = TRUE,
                      key = NULL) {
   language <- sc_language(language, c("en", "de", "both"))
   both <- language == "both"
   if (both)
     language <- "de"
-  res <- sc_table_json_post(readLines(json_file, warn = FALSE), language, add_totals, key) %>%
+  if (!is.null(json_file))
+    json <- readLines(json_file, warn = FALSE)
+  res <- sc_table_json_post(json, language, add_totals, key) %>%
     sc_table_class$new(file = json_file, add_totals = add_totals)
   if (both)
     res$add_language("en", key)

--- a/man/sc_table.Rd
+++ b/man/sc_table.Rd
@@ -22,6 +22,9 @@ sc_table_saved(table_uri, language = NULL, key = NULL, server = "ext")
 \item{json_file}{path to a json file, which was downloaded via the STATcube
 GUI ("Open Data API Abfrage")}
 
+\item{json}{A string that represents a json query from the STATcube GUI,
+imported using, e.g., readLines(json_file)}
+
 \item{language}{The language to be used for labeling. \code{"en"} (the default)
 will use english. \code{"de"} uses german.
 The third option \code{"both"} will import both languages by sending two requests


### PR DESCRIPTION
Currently `sc_table` only allows json _files_ to be used. This is a limitation for certain use cases (when you, e.g. want to dynamically update the query or want to bundle the json query with R code).

This commit is a quick fix  that allows the user to provide a json query from an R object. 

The implementation preserves the current behaviour: If provided, the `json_file` is read in an takes precedence over the new `json` parameter. If no `json_file` is provided the user-supplied `json` query is sent to the server instead.